### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jieba==0.42.1
 pydub==0.24.1
 pyaudio==0.2.11
 tensorflow>=1.13.1
+python_speech_features


### PR DESCRIPTION
fix the error of "ModuleNotFoundError: No module named 'python_speech_features'" when running `pip3 install -r requirements.txt`